### PR TITLE
Explicitly specify features needed for syn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ colors = ["yansi"]
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-syn = "2.0"
 yansi = { version = "1.0.0-rc", optional = true }
+
+[dependencies.syn]
+version = "2"
+default-features = false
+features = ["parsing", "printing"]
 
 [build-dependencies]
 version_check = "0.9.4"
@@ -26,3 +30,7 @@ version_check = "0.9.4"
 [dev-dependencies]
 trybuild = "1.0"
 diagnostic-example = { path = "example/" }
+
+[workspace]
+# Needed to keep features for dependencies & dev-dependencies seperate
+resolver = "2"


### PR DESCRIPTION
Requires switch to `resolver = "2"`, so that features for
dev-dependencies and regular dependencies are separate.

Otherwise, our dev-dependency on `trybuild` would transitively
include the default syn features.

It appears the "printing" dependency is not directly required, it is only needed by the tests.
However, I have added it because it's used for the 'Spanned' trait,
which is likely needed in the future.

Also, we already have a dependency on the 'quote' crate,
so the additional "printing" feature doesn't pull in much more.

Fixes issue #4
