### PR TITLE
README: correct crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Diagnostics for stable and nightly proc-macros!
 
 ```toml
 [dependencies]
-proc_macro2_diagnostics = "0.10"
+proc-macro2-diagnostics = "0.10"
 ```
 
 2. Import `SpanDiagnosticExt` and use its methods on a `proc_macro2::Span` to
@@ -57,7 +57,7 @@ default features:
 
 ```toml
 [dependencies]
-proc_macro2_diagnostics = { version = "0.10", default-features = false }
+proc-macro2-diagnostics = { version = "0.10", default-features = false }
 ```
 
 The compiler always colors diagnostics on nightly.


### PR DESCRIPTION
It is hyphenated: https://crates.io/crates/proc-macro2-diagnostics.