### PR TITLE
Make nightly detection opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/proc-macro2-diagnostics"
 [features]
 default = ["colors"]
 colors = ["yansi"]
+nightly = ["dep:version_check"]
 
 [dependencies]
 quote = "1.0"
@@ -25,7 +26,7 @@ default-features = false
 features = ["parsing", "printing"]
 
 [build-dependencies]
-version_check = "0.9.4"
+version_check = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ On stable, due to limitations, any top-level, non-error diagnostics are
 emitted as errors. This will abort compilation. To avoid this, you may want
 to `cfg`-gate emitting non-error diagnostics to nightly.
 
+
+## Nightly detection
+
+If you want to opt in to better diagnostics on nightly compilers at the risk of your
+crate potentially breaking for future nightly versions, enable the `nightly` feature
+in your `Cargo.toml`:
+
+```toml
+[dependencies]
+proc_macro2_diagnostics = { version = "0.10", features = ["nightly"] }
+```
+
+This will cause `proc_macro2_diagnostics` to automatically detect whether you’re
+using a nightly compiler and if so, improve the diagnostics via unstable APIs.
+
 ### Colors
 
 By default, error messages are colored on stable. To disable, disable

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(feature = "nightly")]
     if let Some((version, channel, _)) = version_check::triple() {
         if version.at_least("1.31.0") && channel.supports_features() {
             println!("cargo:rustc-cfg=nightly_diagnostics");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 #![cfg_attr(nightly_diagnostics, feature(proc_macro_diagnostic, proc_macro_span))]
 
 //! Diagnostic emulation on stable and nightly.
@@ -53,6 +54,20 @@
 //! On stable, due to limitations, any top-level, non-error diagnostics are
 //! emitted as errors. This will abort compilation. To avoid this, you may want
 //! to `cfg`-gate emitting non-error diagnostics to nightly.
+//!
+//! # Nightly detection
+//!
+//! If you want to opt in to better diagnostics on nightly compilers at the risk of your
+//! crate potentially breaking for future nightly versions, enable the `nightly` feature
+//! in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! proc_macro2_diagnostics = { version = "0.10", features = ["nightly"] }
+//! ```
+//!
+//! This will cause `proc_macro2_diagnostics` to automatically detect whether you’re
+//! using a nightly compiler and if so, improve the diagnostics via unstable APIs.
 //!
 //! # Colors
 //!


### PR DESCRIPTION
[As you know](https://github.com/SergioBenitez/version_check/pull/23), nightly detection is recommended against by multiple Rust team members for a number of reasons. From the user perspective, nightly detection means that their crate could break at any time when built with a nightly compiler.

This obviously isn’t what a lot of users want out of Rust code, so this PR proposes to make this feature opt-in – users who are okay with the breakage can get better diagnostics, while the default behaviour is to keep the stability guarantees that people expect from Rust.